### PR TITLE
Update konflux Dockerfile to support env

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -19,7 +19,7 @@ COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
 COPY pkg/ pkg/
-COPY config/overlays/rhoai/distributions.json distributions.json
+COPY distributions.json distributions.json
 
 # Build the manager binary
 USER root


### PR DESCRIPTION
Added support to get distributions from env variables, no need for rhoai specific distributions.json