### PR TITLE
feat: disable readiness probe and add startup probe (#157)

### DIFF
--- a/controllers/resource_helper.go
+++ b/controllers/resource_helper.go
@@ -37,13 +37,12 @@ const (
 	maxConfigMapKeyLength = 253
 )
 
-// Readiness probe configuration.
+// Probes configuration.
 const (
-	readinessProbeInitialDelaySeconds = 15 // Time to wait before the first probe
-	readinessProbePeriodSeconds       = 10 // How often to probe
-	readinessProbeTimeoutSeconds      = 5  // When the probe times out
-	readinessProbeFailureThreshold    = 3  // Pod is marked Unhealthy after 3 consecutive failures
-	readinessProbeSuccessThreshold    = 1  // Pod is marked Ready after 1 successful probe
+	startupProbeInitialDelaySeconds = 15 // Time to wait before the first probe
+	startupProbeTimeoutSeconds      = 30 // When the probe times out
+	startupProbeFailureThreshold    = 3  // Pod is marked Unhealthy after 3 consecutive failures
+	startupProbeSuccessThreshold    = 1  // Pod is marked Ready after 1 successful probe
 )
 
 // validConfigMapKeyRegex defines allowed characters for ConfigMap keys.
@@ -72,6 +71,27 @@ func validateConfigMapKeys(keys []string) error {
 	return nil
 }
 
+// getHealthProbe returns the health probe handler for the container.
+func getHealthProbe(instance *llamav1alpha1.LlamaStackDistribution) corev1.ProbeHandler {
+	return corev1.ProbeHandler{
+		HTTPGet: &corev1.HTTPGetAction{
+			Path: "/v1/health",
+			Port: intstr.FromInt(int(getContainerPort(instance))),
+		},
+	}
+}
+
+// getStartupProbe returns the startup probe for the container.
+func getStartupProbe(instance *llamav1alpha1.LlamaStackDistribution) *corev1.Probe {
+	return &corev1.Probe{
+		ProbeHandler:        getHealthProbe(instance),
+		InitialDelaySeconds: startupProbeInitialDelaySeconds,
+		TimeoutSeconds:      startupProbeTimeoutSeconds,
+		FailureThreshold:    startupProbeFailureThreshold,
+		SuccessThreshold:    startupProbeSuccessThreshold,
+	}
+}
+
 // buildContainerSpec creates the container specification.
 func buildContainerSpec(ctx context.Context, r *LlamaStackDistributionReconciler, instance *llamav1alpha1.LlamaStackDistribution, image string) corev1.Container {
 	container := corev1.Container{
@@ -80,19 +100,7 @@ func buildContainerSpec(ctx context.Context, r *LlamaStackDistributionReconciler
 		Resources:       instance.Spec.Server.ContainerSpec.Resources,
 		ImagePullPolicy: corev1.PullAlways,
 		Ports:           []corev1.ContainerPort{{ContainerPort: getContainerPort(instance)}},
-		ReadinessProbe: &corev1.Probe{
-			ProbeHandler: corev1.ProbeHandler{
-				HTTPGet: &corev1.HTTPGetAction{
-					Path: "/v1/health",
-					Port: intstr.FromInt(int(getContainerPort(instance))),
-				},
-			},
-			InitialDelaySeconds: readinessProbeInitialDelaySeconds,
-			PeriodSeconds:       readinessProbePeriodSeconds,
-			TimeoutSeconds:      readinessProbeTimeoutSeconds,
-			FailureThreshold:    readinessProbeFailureThreshold,
-			SuccessThreshold:    readinessProbeSuccessThreshold,
-		},
+		StartupProbe:    getStartupProbe(instance),
 	}
 
 	// Configure environment variables and mounts

--- a/controllers/resource_helper_test.go
+++ b/controllers/resource_helper_test.go
@@ -50,10 +50,10 @@ func TestBuildContainerSpec(t *testing.T) {
 			},
 			image: "test-image:latest",
 			expectedResult: corev1.Container{
-				Name:           llamav1alpha1.DefaultContainerName,
-				Image:          "test-image:latest",
-				Ports:          []corev1.ContainerPort{{ContainerPort: llamav1alpha1.DefaultServerPort}},
-				ReadinessProbe: newDefaultReadinessProbe(llamav1alpha1.DefaultServerPort),
+				Name:         llamav1alpha1.DefaultContainerName,
+				Image:        "test-image:latest",
+				Ports:        []corev1.ContainerPort{{ContainerPort: llamav1alpha1.DefaultServerPort}},
+				StartupProbe: newDefaultStartupProbe(llamav1alpha1.DefaultServerPort),
 				VolumeMounts: []corev1.VolumeMount{{
 					Name:      "lls-storage",
 					MountPath: llamav1alpha1.DefaultMountPath,
@@ -89,10 +89,10 @@ func TestBuildContainerSpec(t *testing.T) {
 			},
 			image: "test-image:latest",
 			expectedResult: corev1.Container{
-				Name:           "custom-container",
-				Image:          "test-image:latest",
-				Ports:          []corev1.ContainerPort{{ContainerPort: 9000}},
-				ReadinessProbe: newDefaultReadinessProbe(9000),
+				Name:         "custom-container",
+				Image:        "test-image:latest",
+				Ports:        []corev1.ContainerPort{{ContainerPort: 9000}},
+				StartupProbe: newDefaultStartupProbe(9000),
 				Resources: corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
 						corev1.ResourceCPU:    resource.MustParse("1"),
@@ -124,12 +124,12 @@ func TestBuildContainerSpec(t *testing.T) {
 			},
 			image: "test-image:latest",
 			expectedResult: corev1.Container{
-				Name:           llamav1alpha1.DefaultContainerName,
-				Image:          "test-image:latest",
-				Command:        []string{"/custom/entrypoint.sh"},
-				Args:           []string{"--config", "/etc/config.yaml", "--debug"},
-				Ports:          []corev1.ContainerPort{{ContainerPort: llamav1alpha1.DefaultServerPort}},
-				ReadinessProbe: newDefaultReadinessProbe(llamav1alpha1.DefaultServerPort),
+				Name:         llamav1alpha1.DefaultContainerName,
+				Image:        "test-image:latest",
+				Command:      []string{"/custom/entrypoint.sh"},
+				Args:         []string{"--config", "/etc/config.yaml", "--debug"},
+				Ports:        []corev1.ContainerPort{{ContainerPort: llamav1alpha1.DefaultServerPort}},
+				StartupProbe: newDefaultStartupProbe(llamav1alpha1.DefaultServerPort),
 				VolumeMounts: []corev1.VolumeMount{{
 					Name:      "lls-storage",
 					MountPath: llamav1alpha1.DefaultMountPath,
@@ -160,7 +160,7 @@ func TestBuildContainerSpec(t *testing.T) {
 				Image:           "test-image:latest",
 				ImagePullPolicy: corev1.PullAlways,
 				Ports:           []corev1.ContainerPort{{ContainerPort: llamav1alpha1.DefaultServerPort}},
-				ReadinessProbe:  newDefaultReadinessProbe(llamav1alpha1.DefaultServerPort),
+				StartupProbe:    newDefaultStartupProbe(llamav1alpha1.DefaultServerPort),
 				Command:         []string{"python", "-m", "llama_stack.distribution.server.server"},
 				Args:            []string{"--config", "/etc/llama-stack/run.yaml"},
 				Env: []corev1.EnvVar{
@@ -192,7 +192,7 @@ func TestBuildContainerSpec(t *testing.T) {
 			assert.Equal(t, tc.expectedResult.VolumeMounts, result.VolumeMounts)
 			assert.Equal(t, tc.expectedResult.Command, result.Command)
 			assert.Equal(t, tc.expectedResult.Args, result.Args)
-			assert.Equal(t, tc.expectedResult.ReadinessProbe, result.ReadinessProbe)
+			assert.Equal(t, tc.expectedResult.StartupProbe, result.StartupProbe)
 		})
 	}
 }
@@ -648,10 +648,10 @@ func TestValidateConfigMapKeys(t *testing.T) {
 	}
 }
 
-// newDefaultReadinessProbe returns a Kubernetes HTTP readiness probe that checks
+// newDefaultStartupProbe returns a Kubernetes HTTP readiness probe that checks
 // the "/v1/health" endpoint on the given port using default timing and
 // threshold settings.
-func newDefaultReadinessProbe(port int32) *corev1.Probe {
+func newDefaultStartupProbe(port int32) *corev1.Probe {
 	return &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{
 			HTTPGet: &corev1.HTTPGetAction{
@@ -659,10 +659,9 @@ func newDefaultReadinessProbe(port int32) *corev1.Probe {
 				Port: intstr.FromInt(int(port)),
 			},
 		},
-		InitialDelaySeconds: readinessProbeInitialDelaySeconds,
-		PeriodSeconds:       readinessProbePeriodSeconds,
-		TimeoutSeconds:      readinessProbeTimeoutSeconds,
-		FailureThreshold:    readinessProbeFailureThreshold,
-		SuccessThreshold:    readinessProbeSuccessThreshold,
+		InitialDelaySeconds: startupProbeInitialDelaySeconds,
+		TimeoutSeconds:      startupProbeTimeoutSeconds,
+		FailureThreshold:    startupProbeFailureThreshold,
+		SuccessThreshold:    startupProbeSuccessThreshold,
 	}
 }


### PR DESCRIPTION
Problem: The current readiness probe fails during documentation ingestion because the endpoint is blocked by synchronous code. This causes the pod to flap in and out of service, even though the process itself is healthy and simply busy. Ending up with pod restart since the Readiness probe keeps failing.

Solution: Replace the readiness probe with a startup probe. This allows the pod to survive long ingestion periods without being prematurely marked unready by Kubernetes. We disable the Readiness probe for now but still ensure some basic health functionality for startup.

Tradeoff: Once the startup probe succeeds, Kubernetes will assume the pod remains ready for traffic. This means we lose the ongoing readiness check and a pod that later becomes overloaded or blocked will still receive traffic until the liveness probe detects a failure. I'm accepting this tradeoff to eliminate flakiness during ingestion, as rewriting the app to be async or decoupling health checks is not feasible right now.

What's next: once llama-stack has fixed the code to be async we could re-enable the Readiness probes.

Other options considered:

* Ability to disable Readiness probe via CRD flag, feels invasive
* Tweak the Readiness probe, we will never get it right, it will work sometimes but will end up being flaky during ingestion.


(cherry picked from commit b9fb3613697ba0aeb610689f9c4e6ce2a69b2229) (cherry picked from commit 89729f003c0a45e827a1cff18bc73429e490a5e3)