### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for odh-llama-stack-k8s-operator-v2-23

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -46,4 +46,5 @@ LABEL com.redhat.component="odh-llama-stack-k8s-operator-container" \
       io.openshift.expose-services="" \
       io.k8s.display-name="odh-llama-stack-k8s-operator" \
       io.k8s.description="odh-llama-stack-k8s-operator" \
-      com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
+      com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf" \
+      cpe="cpe:/a:redhat:openshift_ai:2.23::el9"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
