### PR TITLE
ogx-module: add Dockerfile.konflux with pre-fetched manifests for hermetic builds

### DIFF
--- a/.tekton/odh-ogx-module-operator-pull-request.yaml
+++ b/.tekton/odh-ogx-module-operator-pull-request.yaml
@@ -25,16 +25,16 @@ spec:
   - name: output-image
     value: quay.io/rhoai/pull-request-pipelines:odh-ogx-module-operator-{{revision}}
   - name: dockerfile
-    value: Dockerfile.konflux
+    value: ogx-module/Dockerfile.konflux
   - name: path-context
-    value: ogx-module/
+    value: .
   - name: image-expires-after
     value: 5d
   - name: enable-slack-failure-notification
     value: "false"
   - name: prefetch-input
     value: |
-      [{"type": "gomod", "path": "ogx-module/"}]
+      [{"type": "gomod", "path": "ogx-module"}]
   - name: build-platforms
     value:
     - linux/x86_64

--- a/ogx-module/.gitignore
+++ b/ogx-module/.gitignore
@@ -1,4 +1,4 @@
-# Downloaded manifests (fetched by get-manifests.sh)
+# Downloaded manifests (fetched by get-manifests.sh for local dev)
 config/manifests/ogx/
 
 # Built binary

--- a/ogx-module/Dockerfile.konflux
+++ b/ogx-module/Dockerfile.konflux
@@ -1,3 +1,4 @@
+# Build the ogx-module manager binary.
 FROM registry.redhat.io/ubi9/go-toolset:1.25@sha256:90a36bc2013b3fcb28e2a4b082c9b895d7c2c679e58b95aed9721970f3339d0e AS builder
 ARG TARGETOS=linux
 ARG TARGETARCH
@@ -19,21 +20,12 @@ COPY ogx-module/pkg/ pkg/
 # Build the manager binary.
 RUN CGO_ENABLED=${CGO_ENABLED} GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -o /workspace/bin/manager ./cmd/ogx-module
 
-# Copy the module hack scripts and the root OGX operator manifests source, then
-# stage the root operator manifests into config/manifests inside the image build.
-COPY ogx-module/hack/ hack/
-COPY config/ ../config/
-RUN USE_LOCAL=true bash hack/get_manifests.sh
-
-# OpenShift may run the container with an arbitrary UID, so make the staged
-# manifests readable in the final image.
-RUN chmod -R a+rX config/manifests/
-
+# Runtime
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:44bc70ef6e6ea9a70e353be97f4722e10358d09fbb9494ca943b2a641049690e
 WORKDIR /
 
 COPY --from=builder /workspace/bin/manager .
-COPY --from=builder /workspace/ogx-module/config/manifests/ /manifests/
+COPY config/ /manifests/ogx/
 
 USER 1001
 
@@ -42,9 +34,9 @@ ENTRYPOINT ["/manager"]
 LABEL com.redhat.component="odh-ogx-module-container" \
       description="OGX Module controller that manages OGX operator deployment and lifecycle" \
       summary="OGX Module controller that manages OGX operator deployment and lifecycle" \
-      name="rhoai/odh-ogx-module-rhel9" \
+      name="rhoai/odh-ogx-module-operator-rhel9" \
       maintainer="['managed-open-data-hub@redhat.com']" \
       io.openshift.expose-services="" \
-      io.k8s.display-name="odh-ogx-module" \
-      io.k8s.description="odh-ogx-module" \
+      io.k8s.display-name="odh-ogx-module-operator" \
+      io.k8s.description="odh-ogx-module-operator" \
       com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"


### PR DESCRIPTION
Adds Konflux-compatible build support for the ogx-module. The existing Dockerfile relies on hack/get_manifests.sh to fetch operator manifests at build time, which is incompatible with Konflux hermetic builds.
